### PR TITLE
CI: add a way to rebuild the docs easily

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,6 +3,11 @@ name: Publish Docs
 on:
   push:
     branches: [master, release/**, testing]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to rebuild the docs
+        required: true
 
 jobs:
   publish-docs:


### PR DESCRIPTION
Add a workflow_dispatch so we can update the docs by pressing a button
in the UI instead of a dummy PR