### PR TITLE
architecture: remove note about restd only for focal

### DIFF
--- a/architecture.rst
+++ b/architecture.rst
@@ -34,8 +34,7 @@ as part of the slurm-core offering:
 
 * SLURM control node (running ``slurmctld``)
 
-* SLURM REST service (running ``slurmrestd``) - currently only available for
-  Ubuntu Focal
+* SLURM REST service (running ``slurmrestd``)
 
 Additionally we include the `Node Health Check (NHC)
 <https://github.com/mej/nhc>`_ with a minimal configuration and checks to


### PR DESCRIPTION
Slurmrestd is now available on both CentOS7 and Ubuntu 20.04.

To be merged after https://github.com/omnivector-solutions/slurm-charms/pull/92