### PR TITLE
Improve osd description with configless mode

### DIFF
--- a/architecture.rst
+++ b/architecture.rst
@@ -3,12 +3,18 @@
 ================
 OSD Architecture
 ================
+
 The Omnivector SLURM Distribution is built on a suite of automations called
-"charms".  Charms are the operational components that describe the lifecycle of
-a SLURM cluster.  A full SLURM deployment comes in the form of multiple charms, one
-for each component of SLURM. A "bundle" is a yaml file where multiple charms
-can be defined. We use bundles to describe the interconnectivity and
+"charms". Charms are the operational components that describe the lifecycle of
+a SLURM cluster. A full SLURM deployment comes in the form of multiple charms,
+one for each component of SLURM. A "bundle" is a YAML file where multiple
+charms can be defined. We use bundles to describe the interconnectivity and
 configuration of groups of charms.
+
+OSD sets up the SLURM cluster in `configless mode
+<https://slurm.schedmd.com/configless_slurm.html>`_. In this mode, the compute
+and login nodes automatically update their configuration based on the
+controller node.
 
 Slurm Charms
 ------------
@@ -28,17 +34,21 @@ OSD Components
 The Omnivector Slurm Distribution supports the following charm components
 as part of the slurm-core offering:
 
-* Compute nodes (running ``slurmd``)
+* `slurmd <https://charmhub.io/slurmd>`_: Compute and login nodes (running
+  ``slurmd``)
 
-* SLURM database node (running ``slurmdbd``)
+* `slurmdbd <https://charmhub.io/slurmdbd>`_: SLURM database node (running
+  ``slurmdbd``)
 
-* SLURM control node (running ``slurmctld``)
+* `slurmctld <https://charmhub.io/slurmctld>`_: SLURM control node (running
+  ``slurmctld``)
 
-* SLURM REST service (running ``slurmrestd``)
+* `slurmrestd <https://charmhub.io/slurmrestd>`_: SLURM REST service (running
+  ``slurmrestd``)
 
 Additionally we include the `Node Health Check (NHC)
 <https://github.com/mej/nhc>`_ with a minimal configuration and checks to
-ensure the ``slurm`` and ``munge`` processes are active.  It is possible, and
+ensure the ``slurm`` and ``munge`` processes are active. It is possible, and
 recommended, that the cluster administrator extends these checks. Check
 :ref:`nhc` section for details on how to configure it.
 

--- a/architecture.rst
+++ b/architecture.rst
@@ -11,10 +11,9 @@ one for each component of SLURM. A "bundle" is a YAML file where multiple
 charms can be defined. We use bundles to describe the interconnectivity and
 configuration of groups of charms.
 
-OSD sets up the SLURM cluster in `configless mode
-<https://slurm.schedmd.com/configless_slurm.html>`_. In this mode, the compute
-and login nodes automatically update their configuration based on the
-controller node.
+OSD provisions SLURM to operate in configless mode
+<https://slurm.schedmd.com/configless_slurm.html>`_. In this mode, the ``slurmctld`` process does the work of
+distributing the ``slurm.conf`` file to the nodes running ``slurmd``.
 
 Slurm Charms
 ------------

--- a/configuration/configuration.rst
+++ b/configuration/configuration.rst
@@ -1,3 +1,5 @@
+.. _configuration-and-administration:
+
 ================================
 Configuration and Administration
 ================================

--- a/contributing.rst
+++ b/contributing.rst
@@ -143,8 +143,10 @@ the charms. To clone and build:
 After the ``.charm`` artifacts have been produced, ``juju`` can be used to
 deploy the built charms to a cloud environment of your choosing. There are two
 primary ways to deploy the charms after building them:
+
 - use Juju to deploy the built charms directly e.g.
   ``juju deploy ./slurmd.charm``
+
 - deploy the local development bundle contained in `slurm-bundles
   <https://github.com/omnivector-solutions/slurm-bundles>`_. The slurm-bundles
   contain a helper Makefile that provide a way to easily deploy the built

--- a/operations/overview.rst
+++ b/operations/overview.rst
@@ -4,19 +4,27 @@
 Operations
 ==========
 
-The Omnivector Slurm Distribution can be configured to the extent that you can configure slurm itself.
-Meaning that all upstream slurm configurations are supported by OSD.
+The Omnivector Slurm Distribution can be configured to the extent that you can configure SLURM itself.
+Meaning that all upstream SLURM configurations are supported by OSD.
 
 The operational magic in OSD is encapsulated in ops code called **charms**. We have curated a suite
-of automation for each Slurm component: ``slurmctld``, ``slurmd``, ``slurmdbd``, and ``slurmrestd``.
+of automation for each SLURM component: ``slurmctld``, ``slurmd``, ``slurmdbd``, and ``slurmrestd``.
 
-The ``slurm.conf`` file can be customized through the slurm charm configuration options.
 Each slurm component charm provides a set of options that enable operators/administrators to operate the cluster.
+
+The ``slurm.conf`` file can be customized through the ``slurmctld`` charm
+configuration options. There is no need to manually update this file in all
+compute nodes: OSD combines the power of Juju operations with SLURM in
+configless mode (see :ref:`architecture` for details) to configure all the
+nodes in the cluster with one single command. This also means that any
+modification to a node's ``slurmc.conf`` file will be discarded.
 
 Alongside the capability to manage the ``slurm.conf``, the charms also provide a set of operational
 tools called *actions*.
 
-Find below a list of operations on how to manage and configure OSD:
+Find below a list of operations on how to manage and configure OSD. Refer to
+:ref:`configuration-and-administration` for a complete list of all
+configuration options and actions.
 
 .. toctree::
    :maxdepth: 2

--- a/operations/overview.rst
+++ b/operations/overview.rst
@@ -17,7 +17,7 @@ configuration options. There is no need to manually update this file in all
 compute nodes: OSD combines the power of Juju operations with SLURM in
 configless mode (see :ref:`architecture` for details) to configure all the
 nodes in the cluster with one single command. This also means that any
-modification to a node's ``slurmc.conf`` file will be discarded.
+modification to a node's ``slurm.conf`` file will be discarded.
 
 Alongside the capability to manage the ``slurm.conf``, the charms also provide a set of operational
 tools called *actions*.


### PR DESCRIPTION
Mention slurm configless mode in architecture and operations.

fix #28