### PR TITLE
monitoring: document slurm-exporter

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -216,13 +216,14 @@ The ``slurm-addons`` directory contains overlays to extend Slurm with plugins:
   to collect profiling information about the jobs. See
   :ref:`influxdb-profiling` for details on usage.
 - ``slurm-addons/monitoring.yaml``: overlay to deploy `prometheus2
-  <https://charmhub.io/prometheus2>`_ and `prometheus-node-exporter
-  <https://charmhub.io/prometheus-node-exporter>`_ for cluster monitoring. See
-  :ref:`monitoring` for details on usage.
-- ``slurm-addons/elasticsearch-acct.yaml``: overlay to deploy `elasticsearch`
+  <https://charmhub.io/prometheus2>`_, `prometheus-node-exporter
+  <https://charmhub.io/prometheus-node-exporter>`_ and `slurm-exporter
+  <https://charmhub.io/slurm-exporter>`_ for cluster monitoring. See
+  :ref:`monitoring` for details on usage.  -
+  ``slurm-addons/elasticsearch-acct.yaml``: overlay to deploy `elasticsearch`
   and relate it to ``slurmctld`` to collect accounting information about the
-  jobs. See :ref:`elasticsearch-accounting` for details.
-- ``slurm-addons/fluentbit.yaml``: overlay to deploy `fluentbit` and relate it
+  jobs. See :ref:`elasticsearch-accounting` for details.  -
+  ``slurm-addons/fluentbit.yaml``: overlay to deploy `fluentbit` and relate it
   to the ``slurm-charms`` to forward logs to a centralized system. See
   :ref:`logging` for details.
 

--- a/operations/monitoring.rst
+++ b/operations/monitoring.rst
@@ -14,8 +14,6 @@ and each individual node.
 Prometheus node_exporter
 ========================
 
-"in all nodes of the cluster"
-
 The subordinate charm `prometheus-node-exporter <https://charmhub.io/prometheus-node-exporter>`_
 can be used to to export machine metrics to a Prometheus instance. To monitor
 all nodes in the cluster, first deploy the application
@@ -40,14 +38,14 @@ Deploy Prometheus and relate it to node exporter to access this functionality:
    $ juju deploy prometheus2
    $ juju relate prometheus-node-exporter:prometheus prometheus2:scrape
 
-Please refer to these charm's documentation for configuration details.
+Please refer to these charms' documentation for configuration details.
 
 
 Prometheus Slurm exporter
 =========================
 
 The subordinate charm `slurm-exporter
-<https://charmhub.io/slurm-exporter>`_ exports metrics about Slurm:
+<https://charmhub.io/slurm-exporter>`_ exports metrics about Slurm, such as the
 state of nodes, jobs, partitions, accounts, scheduler, CPUs, and GPUs. To
 monitor the cluster, deploy the application and relate it to
 ``slurmrestd-charm``:
@@ -75,8 +73,8 @@ functionality:
    $ juju deploy prometheus2
    $ juju relate prometheus-node-exporter:prometheus prometheus2:scrape
 
-Please refer to these charm's documentation for configuration details.
+Please refer to these charms' documentation for configuration details.
 
 You can use the `Grafana Dashboard 4323
-<https://grafana.com/dashboards/4323>`_.to visualize the metrics exported via
+<https://grafana.com/dashboards/4323>`_ to visualize the metrics exported via
 ``slurm-exporter``.

--- a/operations/monitoring.rst
+++ b/operations/monitoring.rst
@@ -5,18 +5,21 @@ Monitoring
 ==========
 
 We provide a bundle overlay to simplify deploying
-`Prometheus <https://prometheus.io/>`_ and
-`Prometheus node_exporter <https://github.com/prometheus/node_exporter>`_ in
-all nodes of the cluster.
+`Prometheus <https://prometheus.io/>`_,
+`Prometheus node_exporter <https://github.com/prometheus/node_exporter>`_ and
+`slurm-exporter <https://charmhub.io/slurm-exporter>`_ to monitor the cluster
+and each individual node.
 
 
 Prometheus node_exporter
 ========================
 
+"in all nodes of the cluster"
+
 The subordinate charm `prometheus-node-exporter <https://charmhub.io/prometheus-node-exporter>`_
 can be used to to export machine metrics to a Prometheus instance. To monitor
 all nodes in the cluster, first deploy the application
-*prometheus-node-exporter* and then relate it to the nodes to be monitored:
+``prometheus-node-exporter`` and then relate it to the nodes to be monitored:
 
 .. code-block:: bash
 
@@ -35,6 +38,45 @@ Deploy Prometheus and relate it to node exporter to access this functionality:
 .. code-block:: bash
 
    $ juju deploy prometheus2
-   $ juju relate prometheus-node-exporter prometheus2
+   $ juju relate prometheus-node-exporter:prometheus prometheus2:scrape
 
 Please refer to these charm's documentation for configuration details.
+
+
+Prometheus Slurm exporter
+=========================
+
+The subordinate charm `slurm-exporter
+<https://charmhub.io/slurm-exporter>`_ exports metrics about Slurm:
+state of nodes, jobs, partitions, accounts, scheduler, CPUs, and GPUs. To
+monitor the cluster, deploy the application and relate it to
+``slurmrestd-charm``:
+
+.. code-block:: bash
+
+   $ juju deploy slurm-exporter
+   $ juju relate slurm-exporter slurmrestd
+
+.. note::
+
+   We recommend deploying ``slurm-exporter`` in the ``slurmrestd`` node. This
+   component could be deployed in other nodes.
+
+This charm exposes by default all the metrics on endpoint ``/metrics`` using
+the port ``9120``.
+
+The charm ``slurm-exporter`` can be related to the `prometheus2
+<https://charmhub.io/prometheus2>`_ charm to automatically scrape its metrics.
+Deploy Prometheus and relate it to ``slurm-exporter`` to access this
+functionality:
+
+.. code-block:: bash
+
+   $ juju deploy prometheus2
+   $ juju relate prometheus-node-exporter:prometheus prometheus2:scrape
+
+Please refer to these charm's documentation for configuration details.
+
+You can use the `Grafana Dashboard 4323
+<https://grafana.com/dashboards/4323>`_.to visualize the metrics exported via
+``slurm-exporter``.


### PR DESCRIPTION
For our new charm: https://github.com/omnivector-solutions/charm-slurm-exporter/

Depends on https://github.com/omnivector-solutions/slurm-bundles/pull/24

Online at: https://omnivector-solutions.github.io/osd-documentation/testing/operations/monitoring.html