### PR TITLE
Update dependencies on publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: "Install dependencies"
         run: |
           sudo apt update
-          sudo apt install -y graphviz enchant python3-enchant hunspell
+          sudo apt install -y graphviz enchant-2 python3-enchant hunspell
           pip install -r requirements.txt
 
       - name: "Build the HTML docs"


### PR DESCRIPTION
**What** 

change `enchant` by `enchant-2`

**Why**

`enchant` is not available on Ubuntu 22.04